### PR TITLE
Add homepage preview animation.

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -10,8 +10,10 @@ interface NavbarHandle {
 
 interface NavbarSpecs {
   selectedApp: app | null,
-  setSelectedApp: Dispatch<SetStateAction<app | null>>
+  setSelectedApp: Dispatch<SetStateAction<app | null>>,
   setAppHovered: Dispatch<SetStateAction<app | null>>,
+  appHovered: app | null,
+  setPreviewAnimationSaveState: Dispatch<SetStateAction<app | null>>,
 }
 
 const Navbar = forwardRef<NavbarHandle, NavbarSpecs>((props: NavbarSpecs, ref) => {
@@ -19,6 +21,8 @@ const Navbar = forwardRef<NavbarHandle, NavbarSpecs>((props: NavbarSpecs, ref) =
     selectedApp,
     setSelectedApp,
     setAppHovered,
+    appHovered,
+    setPreviewAnimationSaveState,
   } = props;
 
   const apps: app[] = applications;
@@ -125,10 +129,14 @@ const Navbar = forwardRef<NavbarHandle, NavbarSpecs>((props: NavbarSpecs, ref) =
       const appName: string | application = target.getAttribute('data-name');
       const app: app | undefined = apps.find((app) => app.name === appName);
       setAppHovered(app ?? null);
+      setPreviewAnimationSaveState(app ?? null);
     };
 
     const handleMouseOut: () => void = () => {
       setAppHovered(null);
+      setTimeout(() => {
+        if (!appHovered) setPreviewAnimationSaveState(null);
+      }, 800);
     };
 
     Array.from(navbarAppIconsContainers).forEach(appContainer => {
@@ -142,7 +150,13 @@ const Navbar = forwardRef<NavbarHandle, NavbarSpecs>((props: NavbarSpecs, ref) =
         appContainer.removeEventListener('mouseout', handleMouseOut);
       });
     };
-  }, [navbarAppIconsContainers, setAppHovered, apps]);
+  }, [
+    navbarAppIconsContainers,
+    setAppHovered,
+    setPreviewAnimationSaveState,
+    appHovered,
+    apps
+  ]);
 
   return (
     <>

--- a/src/pages/homepage/Homepage.scss
+++ b/src/pages/homepage/Homepage.scss
@@ -69,6 +69,24 @@
             h1 {
                 font-size: 24px;
                 margin-bottom: 265px;
+                transition: opacity 1s ease 0.4s;
+                z-index: 0;
+            }
+
+            .fadeIn {
+                opacity: 1;
+            }
+
+            .fadeOut {
+                opacity: 0;
+            }
+
+            .slideIn {
+                right: -30% !important
+            }
+            
+            .slideOut {
+                right: -22% !important
             }
         }
 
@@ -111,13 +129,18 @@
             }
 
             &> :nth-child(2) {
-                width: 57%;
+                width: 55%;
             }
         }
 
         #appPreviewContainer {
+            position: absolute;
+            right: -30%;
+            top: 23%;
             justify-content: flex-start;
             min-height: #{($summaryHeight + $summaryMargin ) * 3 + $summaryMargin};
+            transition: opacity 0.8s ease, right 0.8s ease;
+
             h2 {
                 margin-bottom: 25px;
             }

--- a/src/pages/homepage/Homepage.tsx
+++ b/src/pages/homepage/Homepage.tsx
@@ -14,6 +14,7 @@ function Homepage() {
 
   const [selectedApp, setSelectedApp] = useState<app | null>(null);
   const [appHovered, setAppHovered] = useState<app | null>(null);
+  const [previewAnimationSaveState, setPreviewAnimationSaveState] = useState<app | null>(null);
 
   const handleHomeClick = () => {
     if (!navbarRef.current) return;
@@ -40,7 +41,9 @@ function Homepage() {
           ref={navbarRef}
           selectedApp={selectedApp}
           setSelectedApp={setSelectedApp}
+          appHovered={appHovered}
           setAppHovered={setAppHovered}
+          setPreviewAnimationSaveState={setPreviewAnimationSaveState}
         />
         {selectedApp === null && (
           <>
@@ -59,23 +62,25 @@ function Homepage() {
                   <p>TODO - Progress</p>
                 </Container>
               </Container>
-              <Container direction="column">
-                {appHovered === null ? (
-                  <h1>Welcome back !<br />Hover an application to reveal a preview</h1>
-                ) : (
-                  <Container
-                    id="appPreviewContainer"
-                    direction="column"
-                  >
-                    <h2>{appHovered?.name?.toUpperCase()}</h2>
-                    <p>{appHovered.description}</p>
-                    <img
-                      className="appPreview"
-                      src={appHovered.preview}
-                    >
-                    </img>
-                  </Container>
-                )}
+              <h1 className={appHovered !== null ? `fadeOut` : `fadeIn`}>
+                Welcome back !
+                <br />
+                Hover an application to reveal a preview
+              </h1>
+              <Container
+                id="appPreviewContainer"
+                className={
+                  `${appHovered !== null ? `fadeIn` : `fadeOut`}
+                   ${appHovered !== null ? 'slideOut' : 'slideIn'}`}
+                direction="column"
+              >
+                <h2>{previewAnimationSaveState?.name?.toUpperCase()}</h2>
+                <p>{previewAnimationSaveState?.description}</p>
+                <img
+                  className="appPreview"
+                  src={previewAnimationSaveState?.preview}
+                >
+                </img>
               </Container>
             </Container>
             <CurvedLine />


### PR DESCRIPTION
Change title and preview behaviour to be displayed at all time. Add a previewAnimation state to keep track of last hovered app and overcome preview slide-out anim to reset its content before the end of anim.

- Set preview to absolute and add transitions
- Manage previewAnimation state in navbar when app is hovered.
- Replace appHovered by previewAnimation in preview content.
- Add slides css classes